### PR TITLE
Restore | divs, classnames, css classes

### DIFF
--- a/src/components/Project/NoteFeed/Note/index.jsx
+++ b/src/components/Project/NoteFeed/Note/index.jsx
@@ -20,6 +20,8 @@ import {
   expanded,
   miniAvatarContainer,
   collapsed,
+	notewrapperPrivate,
+	notewrapperPublic,
 } from './Notes.module.scss';
 
 const Note = ({ note, user, projectManagers, projectId }) => {
@@ -64,7 +66,15 @@ const Note = ({ note, user, projectManagers, projectId }) => {
               starDimension="20px"
               starSpacing=".5px"
             />
-            {note.privateNote ? 'Private Note' : 'Public Note'}
+						{note.privateNote ? (
+							<div onClick={() => setIsEditing(true)} className={notewrapperPrivate}>
+								Private Note
+							</div>
+						) : (
+							<div onClick={() => setIsEditing(true)} className={notewrapperPublic}>
+								Public Note
+							</div>
+						)}
           </div>
           <div className={noteBody}>{content}</div>
         </div>


### PR DESCRIPTION
# Description
restoring 
`			{note.privateNote ? (
							<div onClick={() => setIsEditing(true)} class={notewrapperPrivate}>
								Private Note
							</div>
						) : (
							<div onClick={() => setIsEditing(true)} class={notewrapperPublic}>
								Public Note
							</div>
						)}`

as it was removed and changed during last merge to master
Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

